### PR TITLE
update ansible module names to ansible collections names + remove of deleted ppa + inttention/lengthcheck correction

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@ galaxy_info:
   author: Martin Eskdale Moen 
   description: Provides a basic wireguard role for ubuntu based systems
   license: MIT
-  min_ansible_version: 1.2
+  min_ansible_version: 2.9
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Install kernel headers matching kernel version
-  ansible.built.shell: "apt -y install linux-headers-$(uname -r)"
+  ansible.builtin.shell: "apt -y install linux-headers-$(uname -r)"
 
 - name: Install the WireGuard packages
-  ansible.built.package:
+  ansible.builtin.package:
     name: "{{ item }}"
   with_items:
     - wireguard-dkms

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,9 @@
 ---
 - name: Install kernel headers matching kernel version
-  shell: "apt -y install linux-headers-$(uname -r)"
-
-- name: Add the WireGuard PPA
-  apt_repository:
-    repo: 'ppa:wireguard/wireguard'
-    update_cache: yes
+  ansible.built.shell: "apt -y install linux-headers-$(uname -r)"
 
 - name: Install the WireGuard packages
-  apt:
+  ansible.built.package:
     name: "{{ item }}"
   with_items:
     - wireguard-dkms
@@ -18,7 +13,7 @@
 - include: './public_key.yml'
 
 - name: Generate the client and server configuration files
-  template:
+  ansible.builtin.template:
     src: "{{ item }}.j2"
     dest: "{{ wireguard_path }}/{{ item }}"
     owner: root
@@ -29,7 +24,7 @@
   notify: 'restart wireguard'
 
 - name: Enable the WireGuard service so it starts at boot, and bring up the WireGuard network interface
-  systemd:
+  ansible.builtin.systemd:
     name: wg-quick@wg0-server.service
     enabled: yes
     state: started

--- a/tasks/private_key.yml
+++ b/tasks/private_key.yml
@@ -1,6 +1,6 @@
 ---
   - name: Generate private key
-    shell: umask 077; wg genkey
+    ansible.builtin.shell: umask 077; wg genkey
     register: wireguard_private_key_cmd
     when: wireguard_private_key is not defined or wireguard_private_key == ""
 

--- a/tasks/private_key.yml
+++ b/tasks/private_key.yml
@@ -2,8 +2,8 @@
   - name: Generate private key
     ansible.builtin.shell: umask 077; wg genkey
     register: wireguard_private_key_cmd
-    when: wireguard_private_key is not defined or wireguard_private_key == ""
+    when: wireguard_private_key is not defined or wireguard_private_key|length == 0
 
   - set_fact:
       wireguard_private_key: "{{ wireguard_private_key_cmd.stdout }}"
-    when: wireguard_private_key_cmd is defined and (wireguard_private_key is not defined or wireguard_private_key == "")
+    when: wireguard_private_key_cmd is defined and (wireguard_private_key is not defined or wireguard_private_key|length == 0)

--- a/tasks/public_key.yml
+++ b/tasks/public_key.yml
@@ -1,11 +1,11 @@
 ---
-  - name: Generate public key
-    ansible.builtin.shell: 'echo "{{ wireguard_private_key }}" | wg pubkey'
-    register: wireguard_public_key
-    when: wireguard_public_key is not defined or wireguard_public_key == ""
+- name: Generate public key
+  ansible.builtin.shell: 'echo "{{ wireguard_private_key }}" | wg pubkey'
+  register: wireguard_public_key
+  when: wireguard_public_key is not defined or wireguard_public_key|length == 0
 
-  - name: Save public key
-   ansible.builtin.copy:
-      content: "{{ wireguard_public_key.stdout }}"
-      dest: "{{ wireguard_public_key_file }}"
-    when: wireguard_public_key is defined and wireguard_public_key != ""
+- name: Save public key
+  ansible.builtin.copy:
+    content: "{{ wireguard_public_key.stdout }}"
+    dest: "{{ wireguard_public_key_file }}"
+  when: wireguard_public_key is defined and wireguard_public_key|length == 0

--- a/tasks/public_key.yml
+++ b/tasks/public_key.yml
@@ -1,11 +1,11 @@
 ---
   - name: Generate public key
-    shell: 'echo "{{ wireguard_private_key }}" | wg pubkey'
+    ansible.builtin.shell: 'echo "{{ wireguard_private_key }}" | wg pubkey'
     register: wireguard_public_key
     when: wireguard_public_key is not defined or wireguard_public_key == ""
 
   - name: Save public key
-    copy:
+   ansible.builtin.copy:
       content: "{{ wireguard_public_key.stdout }}"
       dest: "{{ wireguard_public_key_file }}"
     when: wireguard_public_key is defined and wireguard_public_key != ""


### PR DESCRIPTION
i updated ansible module names to ansible collections names which comes w/ ansible 2.9 atleast since ansible changed module to collections because the lack of name space and declutter.
Therefore i also updated the min_ansible_version to 2.9.
I also removed the stop to add the  deleted ppa of wireguard since its now in the ubuntu repositories.
One commit is just a "typo" correction.
May lets improve this this w/ another pr at @botto repo.
Any remarks? lets discuss